### PR TITLE
chore: fix pip encoding error in non-English windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
In systems that are not using the default UTF-8 encoding, installation issues may be encountered.

```shell
Collecting combat
  Using cached combat-0.3.3.tar.gz (34 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "\combat_d6e6d3f664904c00a88fd51448c1d447\setup.py", line 4, in <module>
          long_description = fh.read()
      UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 1917: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```

This PR fixed the issue.